### PR TITLE
Fix parsing cannabinoid from batch codes

### DIFF
--- a/src/utils/batchCodeGenerator.ts
+++ b/src/utils/batchCodeGenerator.ts
@@ -26,12 +26,31 @@ export const generateBatchCode = ({
 export const parseBatchCode = (batchCode: string) => {
   const [mainPart, batchNumber] = batchCode.split('.');
   const [productInfo, dateInfo, dc, oilBatch] = mainPart.split('-');
-  
+
   // Extract dose, cannabinoid, and product acronym
-  const dose = parseInt(productInfo.match(/\d+/)?.[0] || '0');
-  const cannabinoid = productInfo.match(/[A-Za-z]+/)?.[0] || '';
-  const productAbbr = productInfo.slice(dose.toString().length + cannabinoid.length);
-  
+  const doseMatch = productInfo.match(/^\d+/);
+  const dose = parseInt(doseMatch ? doseMatch[0] : '0');
+  let remainder = productInfo.slice(doseMatch ? doseMatch[0].length : 0);
+
+  // Common cannabinoid identifiers ordered by length to avoid partial matches
+  const cannabinoidTokens = ['THCO', 'COMBO', 'CAF', 'FS', 'D9', 'D8'];
+  let cannabinoid = '';
+  let productAbbr = '';
+  for (const token of cannabinoidTokens) {
+    if (remainder.startsWith(token)) {
+      cannabinoid = token;
+      productAbbr = remainder.slice(token.length);
+      break;
+    }
+  }
+
+  // Fallback parsing if token not recognized
+  if (!cannabinoid) {
+    const match = remainder.match(/^[A-Za-z0-9]+/);
+    cannabinoid = match ? match[0] : '';
+    productAbbr = remainder.slice(cannabinoid.length);
+  }
+
   return {
     dose,
     cannabinoid,


### PR DESCRIPTION
## Summary
- improve `parseBatchCode` by properly extracting cannabinoid tokens

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e27c39abc83289ca897e94d3f6b3e